### PR TITLE
Fix compilation error on Ubuntu 22

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -269,6 +269,6 @@ static inline __s64 future_base_time(__s64 base_time, __s64 cycle_time, __s64 no
 }
 
 int if_name_copy(char dest[IFNAMSIZ], const char src[IFNAMSIZ]);
-int uds_copy(char dest[IFNAMSIZ], const char src[IFNAMSIZ]);
+int uds_copy(char dest[UNIX_PATH_MAX], const char src[UNIX_PATH_MAX]);
 
 #endif


### PR DESCRIPTION
On Ubuntu 22.04 (gcc 11.2.0)
Gave this error:
```
cc -DVERSION=\"v0.9-rc2\"  -Wall -Wextra -Werror -Wno-error=sign-compare -Wno-error=missing-field-initializers -Wno-unused-parameter -DHAVE_TX_SWHW -MMD -c src/common.c -o src/common.o
src/common.c:277:19: error: argument 1 of type ‘char[108]’ with mismatched bound [-Werror=array-parameter=]
  277 | int uds_copy(char dest[UNIX_PATH_MAX], const char src[UNIX_PATH_MAX])
      |              ~~~~~^~~~~~~~~~~~~~~~~~~
In file included from src/common.c:25:
src/common.h:272:19: note: previously declared as ‘char[16]’
  272 | int uds_copy(char dest[IFNAMSIZ], const char src[IFNAMSIZ]);
      |              ~~~~~^~~~~~~~~~~~~~
src/common.c:277:51: error: argument 2 of type ‘const char[108]’ with mismatched bound [-Werror=array-parameter=]
  277 | int uds_copy(char dest[UNIX_PATH_MAX], const char src[UNIX_PATH_MAX])
      |                                        ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
In file included from src/common.c:25:
src/common.h:272:46: note: previously declared as ‘const char[16]’
  272 | int uds_copy(char dest[IFNAMSIZ], const char src[IFNAMSIZ]);
      |                                   ~~~~~~~~~~~^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:86: src/common.o] Error 1
```

This commit fix the issue