### PR TITLE
Fix calloc-transposed-args

### DIFF
--- a/src/argparser.c
+++ b/src/argparser.c
@@ -435,7 +435,7 @@ int prog_parse_np_args(int argc, char **argv, struct prog_arg *prog_args,
 	int rc, i, parsed = 0;
 	bool *parsed_arr;
 
-	parsed_arr = calloc(sizeof(bool), prog_args_size);
+	parsed_arr = calloc(prog_args_size, sizeof(bool));
 	if (!parsed_arr)
 		return -ENOMEM;
 

--- a/src/log.c
+++ b/src/log.c
@@ -1056,7 +1056,7 @@ out:
 
 int isochron_log_init(struct isochron_log *log, size_t size)
 {
-	log->buf = calloc(sizeof(char), size);
+	log->buf = calloc(size, sizeof(char));
 	if (!log->buf)
 		return -ENOMEM;
 

--- a/src/orchestrate.c
+++ b/src/orchestrate.c
@@ -1133,7 +1133,7 @@ static int prog_init_receiver_nodes(struct isochron_orch *prog)
 		if (!send->stats_srv.family)
 			continue;
 
-		rcv_node = calloc(sizeof(*rcv_node), 1);
+		rcv_node = calloc(1, sizeof(*rcv_node));
 		if (!rcv_node)
 			return -ENOMEM;
 
@@ -1342,13 +1342,13 @@ static int prog_parse_input_file_linewise(struct isochron_orch *prog,
 				break;
 			}
 
-			curr_node = calloc(sizeof(*curr_node), 1);
+			curr_node = calloc(1, sizeof(*curr_node));
 			if (!curr_node) {
 				rc = -ENOMEM;
 				break;
 			}
 
-			send = calloc(sizeof(*send), 1);
+			send = calloc(1, sizeof(*send));
 			if (!send) {
 				free(curr_node);
 				rc = -ENOMEM;


### PR DESCRIPTION
Compiling with reasonable strict compiler errors gives:

error: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Werror=calloc-transposed-args]