### PR TITLE
common: Fix format string for 64 bit time_t

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -88,7 +88,7 @@ void ns_sprintf(char *buf, __s64 ns)
 {
 	struct timespec ts = ns_to_timespec(ns);
 
-	snprintf(buf, TIMESPEC_BUFSIZ, "%ld.%09ld", ts.tv_sec, ts.tv_nsec);
+	snprintf(buf, TIMESPEC_BUFSIZ, "%lld.%09ld", (long long)ts.tv_sec, ts.tv_nsec);
 }
 
 static const char * const trace_marker_paths[] = {


### PR DESCRIPTION
32 bit systems can have a libc configured with 64 bit wide time_t. Extend the format string for time_t so that it can take 64 bit values.