### PR TITLE
Fix build with GLIBC 2.41

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -38,6 +38,7 @@
 
 #define BIT(nr)			(1UL << (nr))
 
+#ifndef HAVE_SCHED_SETATTR
 struct sched_attr {
 	__u32 size;		/* Size of this structure */
 	__u32 sched_policy;	/* Policy (SCHED_*) */
@@ -57,6 +58,7 @@ static inline int sched_setattr(pid_t pid, const struct sched_attr *attr,
 {
 	return syscall(SYS_sched_setattr, pid, attr, flags);
 }
+#endif
 
 #ifndef SO_TXTIME
 #define SO_TXTIME		61

--- a/src/rcv.c
+++ b/src/rcv.c
@@ -6,6 +6,7 @@
  * Initial prototype based on:
  * - https://gist.github.com/austinmarton/2862515
  */
+#define _GNU_SOURCE
 #include <linux/if_packet.h>
 #include <linux/un.h>
 #include <stdio.h>

--- a/toolchain_deps.sh
+++ b/toolchain_deps.sh
@@ -16,4 +16,17 @@ if [ $? = 0 ]; then
 	EXTRA_CFLAGS="${EXTRA_CFLAGS} -DHAVE_TX_SWHW"
 fi
 
+${CC} ${CFLAGS} -x c -o $(mktemp) - > /dev/null 2>&1 << EOF
+#define _GNU_SOURCE
+#include <sched.h>
+
+int main(void)
+{
+	return sched_setattr(0, NULL, 0);
+}
+EOF
+if [ $? = 0 ]; then
+	EXTRA_CFLAGS="${EXTRA_CFLAGS} -DHAVE_SCHED_SETATTR"
+fi
+
 echo ${EXTRA_CFLAGS}


### PR DESCRIPTION
Starting with GLIBC 2.41, the sched_setattr() function and the corresponding sched_attr structure are provided when _GNU_SOURCE is defined. This causes a build failure due to conflict.

Fix that by just using the GLIBC definition and function when available.